### PR TITLE
chore(ci): add metric assertions

### DIFF
--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -76,7 +76,7 @@ jobs:
             echo "Invalid loss format: $loss"
             exit 1
           fi
-          if ! awk "BEGIN {exit ($loss < 0.1)}"; then
+          if (( $(echo "$loss < 0.1" | bc -l) == 0 )); then
             echo "LOSS $loss is not < 0.1"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -38,6 +38,49 @@ jobs:
           npx playwright install --with-deps || true
           npm run ci:all
 
+      - name: Assert metrics
+        run: |
+          if [ ! -f test-results/lighthouse-report.html ]; then
+            echo "Lighthouse report not found: expected test-results/lighthouse-report.html"
+            exit 1
+          fi
+
+          if [ ! -f test-results/lighthouse-score.txt ]; then
+            echo "Lighthouse score file not found: expected test-results/lighthouse-score.txt"
+            exit 1
+          fi
+
+          if [ ! -f test-results/loss.txt ]; then
+            echo "LOSS file not found: expected test-results/loss.txt"
+            exit 1
+          fi
+
+          if [ ! -f test-results/accuracy.txt ]; then
+            echo "ACCURACY file not found: expected test-results/accuracy.txt"
+            exit 1
+          fi
+
+          score=$(cat test-results/lighthouse-score.txt)
+          min_score=0.89
+          if (( $(echo "$score < $min_score" | bc -l) )); then
+            echo "Lighthouse score $score is below expected >= $min_score"
+            exit 1
+          fi
+
+          loss=$(cat test-results/loss.txt)
+          if (( $(echo "$loss >= 0.1" | bc -l) )); then
+            echo "LOSS $loss is not < 0.1"
+            exit 1
+          fi
+
+          acc=$(cat test-results/accuracy.txt)
+          if (( $(echo "$acc < 0.95" | bc -l) )); then
+            echo "ACCURACY $acc is below expected >= 0.95"
+            exit 1
+          fi
+
+          echo "Metrics passed: Lighthouse score $score >= $min_score, LOSS $loss < 0.1, ACCURACY $acc >= 0.95"
+
       # Open PR with any changes
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -72,12 +72,20 @@ jobs:
           fi
 
           loss=$(cat test-results/loss.txt)
+          if ! [[ "$loss" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "Invalid loss format: $loss"
+            exit 1
+          fi
           if ! awk "BEGIN {exit ($loss < 0.1)}"; then
             echo "LOSS $loss is not < 0.1"
             exit 1
           fi
 
           acc=$(cat test-results/accuracy.txt)
+          if ! [[ "$acc" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "Invalid accuracy format: $acc"
+            exit 1
+          fi
           if ! awk "BEGIN {exit ($acc >= 0.95)}"; then
             echo "ACCURACY $acc is below expected >= 0.95"
             exit 1

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -66,7 +66,7 @@ jobs:
             exit 1
           fi
           min_score=0.89
-          if ! awk "BEGIN {exit ($score >= $min_score)}"; then
+          if ! (( $(echo "$score >= $min_score" | bc -l) )); then
             echo "Lighthouse score $score is below expected >= $min_score"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -82,7 +82,7 @@ jobs:
           fi
 
           acc=$(cat test-results/accuracy.txt)
-          if ! [[ "$acc" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+          if ! [[ "$acc" =~ $number_pattern ]]; then
             echo "Invalid accuracy format: $acc"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -61,7 +61,7 @@ jobs:
           fi
 
           score=$(cat test-results/lighthouse-score.txt)
-          if ! [[ "$score" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+          if ! [[ "$score" =~ $number_pattern ]]; then
             echo "Invalid score format: $score"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -62,19 +62,19 @@ jobs:
 
           score=$(cat test-results/lighthouse-score.txt)
           min_score=0.89
-          if (( $(echo "$score < $min_score" | bc -l) )); then
+          if ! awk "BEGIN {exit ($score >= $min_score)}"; then
             echo "Lighthouse score $score is below expected >= $min_score"
             exit 1
           fi
 
           loss=$(cat test-results/loss.txt)
-          if (( $(echo "$loss >= 0.1" | bc -l) )); then
+          if ! awk "BEGIN {exit ($loss < 0.1)}"; then
             echo "LOSS $loss is not < 0.1"
             exit 1
           fi
 
           acc=$(cat test-results/accuracy.txt)
-          if (( $(echo "$acc < 0.95" | bc -l) )); then
+          if ! awk "BEGIN {exit ($acc >= 0.95)}"; then
             echo "ACCURACY $acc is below expected >= 0.95"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -86,7 +86,7 @@ jobs:
             echo "Invalid accuracy format: $acc"
             exit 1
           fi
-          if ! awk "BEGIN {exit ($acc >= 0.95)}"; then
+          if (( $(echo "$acc >= 0.95" | bc -l) == 0 )); then
             echo "ACCURACY $acc is below expected >= 0.95"
             exit 1
           fi

--- a/.github/workflows/codex-cron.yaml
+++ b/.github/workflows/codex-cron.yaml
@@ -61,6 +61,10 @@ jobs:
           fi
 
           score=$(cat test-results/lighthouse-score.txt)
+          if ! [[ "$score" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "Invalid score format: $score"
+            exit 1
+          fi
           min_score=0.89
           if ! awk "BEGIN {exit ($score >= $min_score)}"; then
             echo "Lighthouse score $score is below expected >= $min_score"


### PR DESCRIPTION
## Summary
- ensure Codex cron workflow checks for Lighthouse, loss, and accuracy metrics
- fail early when required metric files are missing

## Testing
- `npm test`

Context: previous failing run [link](https://github.com/thebearwithabite/contrastive-goat/actions/runs/17147421817/job/48646242714#step:7:1433)


------
https://chatgpt.com/codex/tasks/task_e_68a951660b48832989c9f0237f6e8eb2